### PR TITLE
Faster FR3 motion: PD torque law and higher Kp gains

### DIFF
--- a/src/DifferentiableOptimizationCBF/three_blocks_controller.py
+++ b/src/DifferentiableOptimizationCBF/three_blocks_controller.py
@@ -89,7 +89,7 @@ class ThreeBlocksController(BaseController):
             "p_error": p_error,
             "p_current": p_current,
             "dp_target": dp_target,
-            "Kp": 0.1 * np.eye(6),
+            "Kp": 1.0 * np.eye(6),
             "dq_nominal": dq_nominal,
             "nullspace_proj": np.eye(9) - pinv_jac @ jacobian,
             "lb": lb,

--- a/src/DifferentiableOptimizationCBF/three_blocks_exp.py
+++ b/src/DifferentiableOptimizationCBF/three_blocks_exp.py
@@ -52,7 +52,13 @@ def main():
             history.append(_info)
 
         # compute torque command
-        τ = 6.0 * (dq_target[:, np.newaxis] - dq[:, np.newaxis]) + G - 0.1 * dq[:, np.newaxis]
+        q_target = dq_target[:, np.newaxis] * env.dt + q[:, np.newaxis]
+        τ = (
+            30 * (q_target - q[:, np.newaxis])
+            + 3.0 * (dq_target[:, np.newaxis] - dq[:, np.newaxis])
+            + G
+            - 0.1 * dq[:, np.newaxis]
+        )
         torques.append(τ)
 
         if i >= 1:

--- a/src/DifferentiableOptimizationCBF/three_blocks_exp.py
+++ b/src/DifferentiableOptimizationCBF/three_blocks_exp.py
@@ -2,13 +2,11 @@ import time
 
 import numpy as np
 
+from DifferentiableOptimizationCBF.envs.three_blocks_env import ThreeBlocksEnv
+from DifferentiableOptimizationCBF.three_blocks_controller import ThreeBlocksController
+
 
 def main():
-    from DifferentiableOptimizationCBF.envs.three_blocks_env import ThreeBlocksEnv
-    from DifferentiableOptimizationCBF.three_blocks_controller import (
-        ThreeBlocksController,
-    )
-
     # create environment
     env = ThreeBlocksEnv(
         render_mode="human",

--- a/src/DifferentiableOptimizationCBF/two_walls_controller.py
+++ b/src/DifferentiableOptimizationCBF/two_walls_controller.py
@@ -79,9 +79,7 @@ class TwoWallsController(BaseController):
             for j in range(4):
                 α, J_link = _αs[j][k], np.array(Js[j][k])
                 αs.append(copy.deepcopy(α))
-                Cs.append(
-                    J_link[-1, 7:][np.newaxis, :] @ Q_mat_link @ info[f"J_{link}"]
-                )
+                Cs.append(J_link[-1, 7:][np.newaxis, :] @ Q_mat_link @ info[f"J_{link}"])
 
         lb = -5.0 * (np.array(αs)[:, np.newaxis] - 1.03)
         C = np.concatenate(Cs, axis=0)
@@ -91,7 +89,7 @@ class TwoWallsController(BaseController):
             "p_error": p_error,
             "p_current": p_current,
             "dp_target": dp_target,
-            "Kp": 0.1 * np.eye(6),
+            "Kp": 0.2 * np.eye(6),
             "dq_nominal": dq_nominal,
             "nullspace_proj": np.eye(9) - pinv_jac @ jacobian,
             "lb": lb,

--- a/src/DifferentiableOptimizationCBF/two_walls_exp.py
+++ b/src/DifferentiableOptimizationCBF/two_walls_exp.py
@@ -2,11 +2,11 @@ import time
 
 import numpy as np
 
+from DifferentiableOptimizationCBF.envs.two_walls_env import TwoWallsEnv
+from DifferentiableOptimizationCBF.two_walls_controller import TwoWallsController
+
 
 def main():
-    from DifferentiableOptimizationCBF.envs.two_walls_env import TwoWallsEnv
-    from DifferentiableOptimizationCBF.two_walls_controller import TwoWallsController
-
     # create environment
     env = TwoWallsEnv(
         render_mode="human",

--- a/src/DifferentiableOptimizationCBF/two_walls_exp.py
+++ b/src/DifferentiableOptimizationCBF/two_walls_exp.py
@@ -49,8 +49,10 @@ def main():
             history.append(_info)
 
         # compute torque command
+        q_target = dq_target[:, np.newaxis] * env.dt + q[:, np.newaxis]
         τ = (
-            6.0 * (dq_target[:, np.newaxis] - dq[:, np.newaxis])
+            30 * (q_target - q[:, np.newaxis])
+            + 3.0 * (dq_target[:, np.newaxis] - dq[:, np.newaxis])
             + G
             - 0.1 * dq[:, np.newaxis]
         )


### PR DESCRIPTION
## Summary
- Switch the FR3 torque law in both `three_blocks_exp.py` and `two_walls_exp.py` from pure velocity feedback (`6.0·(dq_target − dq)`) to a stiffer PD law with an explicit one-step position target (`30·(q_target − q) + 3.0·(dq_target − dq)`), yielding faster, less-laggy tracking.
- Raise the task-space proportional gain `Kp` in `ThreeBlocksController` (0.1 → 1.0) and `TwoWallsController` (0.1 → 0.2) so the CBF-QP nominal velocity drives the end-effector to its target more aggressively.
- Hoist `Env`/`Controller` imports in both experiment scripts from inside `main()` to module top-level for cleaner module structure.